### PR TITLE
Adding genericName and drugType to drug route

### DIFF
--- a/app/routes/drug.js
+++ b/app/routes/drug.js
@@ -4,6 +4,37 @@ export default Ember.Route.extend({
 
   model: function(params) {
     return Ember.RSVP.hash({
+      genericName: $.getJSON('https://api.fda.gov/drug/label.json?search=openfda.unii:"' + params.drug_id + '"&count=openfda.generic_name.exact')
+        .then(function (data) {
+
+          var max = 0;
+          var name = 'Unknown';
+          $.each(data.results, function (key, value) {
+            if(value.count > max)
+            {
+              max= value.count;
+              name = value.term;
+            }
+          });
+          return name;
+        }),
+      drugType: $.getJSON('https://api.fda.gov/drug/label.json?search=openfda.unii:"' + params.drug_id + '"&count=openfda.product_type.exact')
+        .then(function (data) {
+
+          var bOtc = false;
+          var bRx = false;
+          $.each(data.results, function (key, value) {
+            bOtc = bOtc || (value.term.toUpperCase().indexOf('OTC') > -1);
+            bRx = bRx || (value.term.toUpperCase().indexOf('PRESCRIPTION') > -1);
+          });
+          if(bOtc && bRx){
+            return 'Both';
+          }else if(bOtc){
+            return 'OTC';
+          }else{
+            return 'Rx';
+          }
+        }),
       effects: $.getJSON("event?unii=" + params.drug_id),
       recalls: $.getJSON("drug/enforcements?unii=" + params.drug_id),
       interactions: $.getJSON('https://rxnav.nlm.nih.gov/REST/rxcui?idtype=UNII_CODE&id=' + params.drug_id).then(function (data) {

--- a/app/templates/drug.hbs
+++ b/app/templates/drug.hbs
@@ -1,8 +1,24 @@
 <section id="page-header" class="section">
 	<div class="container">
-		<h1>
-			{{drugName}}
-		</h1>
+      <div class="row">
+          <div class="col-xs-1">
+              <!-- values = OTC, Rx, or Both -->
+            {{model.drugType}}
+          </div>
+          <div class="col-xs-11">
+              <h1>
+                {{#if drugName}}
+                  {{drugName}}
+                {{else}}
+                  {{model.genericName}}
+                {{/if}}
+              </h1>
+              <h2>
+                {{model.genericName}}
+              </h2>
+          </div>
+      </div>
+
 	</div>
 </section>
 

--- a/app/templates/drug/_recalls.hbs
+++ b/app/templates/drug/_recalls.hbs
@@ -17,8 +17,9 @@
       <div class="recall">
           <div class="row">
               <div class="col-sm-8 col-md-9">
-                  <h4 class="h3 title-recall"><span class="label label-success">{{recall.status}}</span> {{drugName}}</h4>
+                  <h4 class="h3 title-recall"><span class="label label-success">{{recall.status}}</span> {{recall.openfda.brand_name}}</h4>
                   <p><strong class="prepend">Product Description:</strong> {{recall.product_description}}</p>
+                  <p><strong class="prepend">Identifiers:</strong> {{recall.code_info}}</p>
                   <p><strong class="prepend">Recall Reason:</strong> {{recall.reason_for_recall}}</p>
                   <p><strong class="prepend">Initiation Date:</strong> {{format-date recall.recall_initiation_date}} &bull; <strong class="prepend">Recall Number:</strong> {{recall.recall_number}}</p>
                   <p><strong class="prepend">Report Date:</strong> {{format-date recall.report_date}} &bull; <strong class="prepend">Reporting Firm:</strong> {{recall.recalling_firm}}</p>


### PR DESCRIPTION
Here is the data.  Make it look pretty please.  drugType has three states OTC, Rx, and Both.  If you don't want to create 3 icons you can count Both as OTC.  I also updated the Recall template to get the brand_name and added the lot number.